### PR TITLE
Change playSound to setPlannedRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ BackgroundGeolocation.start(
             }
             return console.error(error);
         }
-        // in case of off-track for example, play a sound:
-        BackgroundGeolocation.playSound({soundFile: "assets/myFile.mp3" });
         return console.log(location);
     }
 ).then(() => {
     // When location updates are no longer needed, the plugin should be stopped by calling
     BackgroundGeolocation.stop();
 });
+
+// Set a planned route to get a notification sound when a new location arrives and it's not on the route:
+        
+BackgroundGeolocation.setPlannedRoute({soundFile: "assets/myFile.mp3", route: [[1,2], [3,4]], distance: 30 });
 
 // If you just want the current location, try something like this. The longer
 // the timeout, the more accurate the guess will be. I wouldn't go below about 100ms.
@@ -177,7 +179,7 @@ Configration specific to Android can be made in `strings.xml`:
 * [`start(...)`](#start)
 * [`stop()`](#stop)
 * [`openSettings()`](#opensettings)
-* [`playSound(...)`](#playsound)
+* [`setPlannedRoute(...)`](#setplannedroute)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -235,23 +237,20 @@ Useful for directing users to enable location services or adjust permissions.
 --------------------
 
 
-### playSound(...)
+### setPlannedRoute(...)
 
 ```typescript
-playSound(options: PlaySoundOptions) => Promise<void>
+setPlannedRoute(options: SetPlannedRouteOptions) => Promise<void>
 ```
 
-Plays a sound file.
-This should be used to play a sound, in the background too.
-The idea behind this is to allow the user to hear a sound when a new location is available or when going off track.
-If you simply need to play a sound, you can use `@capgo/native-audio` plugin instead.
-For Android, there's a need to start monitoring location updates first, otherwise the sound will not play.
+Plays a sound file when the user deviates from the planned route.
+This should be used to play a sound, in the background too (only for native).
 
-| Param         | Type                                                          | Description                       |
-| ------------- | ------------------------------------------------------------- | --------------------------------- |
-| **`options`** | <code><a href="#playsoundoptions">PlaySoundOptions</a></code> | The options for playing the sound |
+| Param         | Type                                                                      | Description                                              |
+| ------------- | ------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **`options`** | <code><a href="#setplannedrouteoptions">SetPlannedRouteOptions</a></code> | The options for setting the planned route and sound file |
 
-**Since:** 7.0.10
+**Since:** 7.0.11
 
 --------------------
 
@@ -300,10 +299,12 @@ Extends the standard Error with optional error codes.
 | **`code`** | <code>string</code> | Optional error code for more specific error handling. | 7.0.0 |
 
 
-#### PlaySoundOptions
+#### SetPlannedRouteOptions
 
-| Prop            | Type                | Description                                                                                                                                                                                             | Since  |
-| --------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| **`soundFile`** | <code>string</code> | The name of the sound file to play. Must be a valid sound relative path in the app's public folder to work for both web and native platforms. There's no need to include the public folder in the path. | 7.0.10 |
+| Prop            | Type                            | Description                                                                                                                                                                                                                                        | Default         | Since  |
+| --------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------ |
+| **`soundFile`** | <code>string</code>             | The name of the sound file to play. Must be a valid sound relative path in the app's public folder to work for both web and native platforms. There's no need to include the public folder in the path.                                            |                 | 7.0.10 |
+| **`route`**     | <code>[number, number][]</code> | The planned route as an array of latitude and longitude pairs. Each pair represents a point on the route. This is used to define a route that the user can follow. The route is used to play a sound when the user deviates from it.               |                 | 7.0.11 |
+| **`distance`**  | <code>number</code>             | The distance in meters that the user must deviate from the planned route to trigger the sound. This is used to determine how far off the route the user can be before the sound is played. If not specified, a default value of 50 meters is used. | <code>50</code> | 7.0.11 |
 
 </docgen-api>

--- a/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
+++ b/android/src/main/java/com/capgo/capacitor_background_geolocation/BackgroundGeolocation.java
@@ -15,7 +15,9 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
 import android.provider.Settings;
+import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.PermissionState;
@@ -27,6 +29,8 @@ import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 import com.google.android.gms.location.LocationServices;
 import java.util.concurrent.CompletableFuture;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 @CapacitorPlugin(
@@ -189,7 +193,7 @@ public class BackgroundGeolocation extends Plugin {
   }
 
   @PluginMethod
-  public void playSound(PluginCall call) {
+  public void setPlannedRoute(PluginCall call) {
     String soundFile = call.getString("soundFile");
     if (soundFile == null || soundFile.isEmpty()) {
       call.reject("Sound file is required");
@@ -202,15 +206,50 @@ public class BackgroundGeolocation extends Plugin {
       );
       return;
     }
-    serviceConnectionFuture
-      .thenAccept(service -> {
-        service.playSound(soundFile);
-        call.resolve();
-      })
-      .exceptionally(throwable -> {
-        call.reject("Failed to play sound: " + throwable.getMessage());
+    try {
+      double[][] javaDoubleArray = getJavaDoubleArray(call);
+      serviceConnectionFuture
+        .thenAccept(service -> {
+          service.setPlannedRoute(
+            soundFile,
+            javaDoubleArray,
+            call.getFloat("distance", 50f)
+          );
+          call.resolve();
+        })
+        .exceptionally(throwable -> {
+          call.reject("Failed to set route: " + throwable.getMessage());
+          return null;
+        });
+    } catch (Exception ex) {
+      call.reject("Unable to parse route parameters");
+    }
+  }
+
+  private static double[][] getJavaDoubleArray(PluginCall call)
+    throws JSONException {
+    JSArray jsArray = call.getArray("route");
+    int rows = jsArray.length();
+    if (rows == 0) {
+      return new double[0][2];
+    }
+
+    JSONArray firstRow = jsArray.getJSONArray(0);
+    int cols = firstRow.length();
+
+    var javaDoubleArray = new double[rows][cols];
+
+    for (int i = 0; i < rows; i++) {
+      JSONArray rowArray = jsArray.getJSONArray(i);
+      if (rowArray.length() != cols) {
+        call.reject("Input array is not a consistent 2D array.");
         return null;
-      });
+      }
+      for (int j = 0; j < cols; j++) {
+        javaDoubleArray[i][j] = rowArray.getDouble(j);
+      }
+    }
+    return javaDoubleArray;
   }
 
   // Checks if device-wide location services are disabled

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -5,5 +5,5 @@ CAP_PLUGIN(BackgroundGeolocation, "BackgroundGeolocation",
     CAP_PLUGIN_METHOD(start, CAPPluginReturnCallback);
     CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(openSettings, CAPPluginReturnPromise);
-    CAP_PLUGIN_METHOD(playSound, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(setPlannedRoute, CAPPluginReturnPromise);
 )

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -165,7 +165,7 @@ export interface CallbackError extends Error {
   code?: string;
 }
 
-export interface PlaySoundOptions {
+export interface SetPlannedRouteOptions {
   /**
    * The name of the sound file to play.
    * Must be a valid sound relative path in the app's public folder to work for both web and native platforms.
@@ -174,6 +174,25 @@ export interface PlaySoundOptions {
    * @example "notification.mp3"
    * */
   soundFile: string;
+  /**
+   * The planned route as an array of latitude and longitude pairs.
+   * Each pair represents a point on the route.
+   * This is used to define a route that the user can follow.
+   * The route is used to play a sound when the user deviates from it.
+   * @since 7.0.11
+   * @example [[40.7128, -74.0060], [34.0522, -118.2437]]
+   */
+  route: [number, number][];
+
+  /**
+   * The distance in meters that the user must deviate from the planned route to trigger the sound.
+   * This is used to determine how far off the route the user can be before the sound is played.
+   * If not specified, a default value of 50 meters is used.
+   * @since 7.0.11
+   * @default 50
+   * @example 50
+   */
+  distance: number;
 }
 
 /**
@@ -243,20 +262,18 @@ export interface BackgroundGeolocationPlugin {
   openSettings(): Promise<void>;
 
   /**
-   * Plays a sound file.
-   * This should be used to play a sound, in the background too.
-   * The idea behind this is to allow the user to hear a sound when a new location is available or when going off track.
-   * If you simply need to play a sound, you can use `@capgo/native-audio` plugin instead.
-   * For Android, there's a need to start monitoring location updates first, otherwise the sound will not play.
+   * Plays a sound file when the user deviates from the planned route.
+   * This should be used to play a sound, in the background too (only for native).
    *
-   * @param options The options for playing the sound
-   * @returns A promise that resolves when the sound is successfully played
+   * @param options The options for setting the planned route and sound file
+   * @returns A promise that resolves when the route is set successfully
    *
-   * @since 7.0.10
+   * @since 7.0.11
    * @example
-   * await BackgroundGeolocation.playSound({
-   *   soundFile: "notification.mp3"
+   * await BackgroundGeolocation.setPlannedRoute({
+   *   soundFile: "notification.mp3",
+   *   route: [[40.7128, -74.0060], [34.0522, -118.2437]]
    * });
    */
-  playSound(options: PlaySoundOptions): Promise<void>;
+  setPlannedRoute(options: SetPlannedRouteOptions): Promise<void>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -5,14 +5,20 @@ import type {
   StartOptions,
   Location,
   CallbackError,
-  PlaySoundOptions,
+  SetPlannedRouteOptions,
 } from "./definitions";
 
 export class BackgroundGeolocationWeb
   extends WebPlugin
   implements BackgroundGeolocationPlugin
 {
+  private static readonly EARTH_RADIUS_M = 6371000;
+
   private watchId: number | undefined;
+  private plannedRoute: [number, number][] = [];
+  private audio: HTMLAudioElement | undefined;
+  private isOffRoute = true;
+  private distanceThreshold = 50;
 
   async start(
     options: StartOptions,
@@ -49,6 +55,18 @@ export class BackgroundGeolocationWeb
           speed: position.coords.speed,
           time: position.timestamp,
         };
+        if (this.audio && this.plannedRoute.length > 0) {
+          const currentPoint: [number, number] = [
+            position.coords.longitude,
+            position.coords.latitude,
+          ];
+          const offRoute =
+            this.distancePointToRoute(currentPoint) > this.distanceThreshold;
+          if (offRoute == true && this.isOffRoute === false) {
+            this.audio.play();
+          }
+          this.isOffRoute = offRoute;
+        }
         callback(location);
       },
       (error) => {
@@ -79,15 +97,116 @@ export class BackgroundGeolocationWeb
     window.alert("Please enable location permissions in your browser settings");
   }
 
-  async playSound(options: PlaySoundOptions): Promise<void> {
+  async setPlannedRoute(options: SetPlannedRouteOptions): Promise<void> {
     if (!options.soundFile) {
       throw new Error("Sound file is required");
     }
-    const audio = new Audio(options.soundFile);
-    try {
-      await audio.play();
-    } catch (error) {
-      throw new Error(`Failed to play sound: ${(error as Error).message}`);
+    this.audio = new Audio(options.soundFile);
+    this.plannedRoute = options.route || [];
+    this.distanceThreshold = options.distance || 50;
+  }
+
+  private toRadians(degrees: number): number {
+    return (degrees * Math.PI) / 180;
+  }
+
+  private haversine(
+    point1: [number, number],
+    point2: [number, number],
+  ): number {
+    const [lon1, lat1] = point1;
+    const [lon2, lat2] = point2;
+    const dLat = this.toRadians(lat2 - lat1);
+    const dLon = this.toRadians(lon2 - lon1);
+
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(this.toRadians(lat1)) *
+        Math.cos(this.toRadians(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return BackgroundGeolocationWeb.EARTH_RADIUS_M * c;
+  }
+
+  private distancePointToLineSegment(
+    point: [number, number],
+    lineStart: [number, number],
+    lineEnd: [number, number],
+  ): number {
+    // Calculate the distances between the three points using Haversine
+    const dist_A_B = this.haversine(point, lineStart);
+    const dist_A_C = this.haversine(point, lineEnd);
+    const dist_B_C = this.haversine(lineStart, lineEnd);
+
+    // Handle the edge case where the line segment is a single point
+    if (dist_B_C === 0) {
+      return dist_A_B;
     }
+
+    // Check if the angles at the line segment's endpoints are obtuse.
+    // We use the Law of Cosines (c^2 = a^2 + b^2 - 2ab*cos(C))
+    // If cos(C) < 0, the angle is obtuse.
+
+    // Angle at B (lineStart)
+    // Use a small epsilon to handle floating point inaccuracies in division by zero
+    const cos_B =
+      (dist_A_B ** 2 + dist_B_C ** 2 - dist_A_C ** 2) /
+      (2 * dist_A_B * dist_B_C + Number.EPSILON);
+    if (cos_B < 0) {
+      return dist_A_B;
+    }
+
+    // Angle at C (lineEnd)
+    const cos_C =
+      (dist_A_C ** 2 + dist_B_C ** 2 - dist_A_B ** 2) /
+      (2 * dist_A_C * dist_B_C + Number.EPSILON);
+    if (cos_C < 0) {
+      return dist_A_C;
+    }
+
+    // If both angles are acute, the closest point is on the line segment itself.
+    // We can calculate the distance (height of the triangle) using its area.
+
+    // 1. Calculate the semi-perimeter of the triangle ABC
+    const s = (dist_A_B + dist_A_C + dist_B_C) / 2;
+
+    // 2. Calculate the area using Heron's formula
+    const area = Math.sqrt(
+      Math.max(0, s * (s - dist_A_B) * (s - dist_A_C) * (s - dist_B_C)),
+    );
+
+    // 3. The distance is the height of the triangle from point A to the base BC
+    // Area = 0.5 * base * height  =>  height = 2 * Area / base
+    return (2 * area) / (dist_B_C + Number.EPSILON);
+  }
+
+  private distancePointToRoute(point: [number, number]): number {
+    // If the route has less than 2 points, we can't form a segment.
+    if (this.plannedRoute.length < 2) {
+      if (this.plannedRoute.length === 1) {
+        return this.haversine(point, this.plannedRoute[0]);
+      }
+      return Infinity; // No line segments to measure against
+    }
+
+    let minDistance = Infinity;
+
+    for (let i = 0; i < this.plannedRoute.length - 1; i++) {
+      const lineStart = this.plannedRoute[i];
+      const lineEnd = this.plannedRoute[i + 1];
+      const distance = this.distancePointToLineSegment(
+        point,
+        lineStart,
+        lineEnd,
+      );
+      if (distance < minDistance) {
+        minDistance = distance;
+      }
+    }
+
+    return minDistance;
   }
 }


### PR DESCRIPTION
It seems that due to thread priority or something related to how Android works, when playing a sound, even in a foreground service from a capacitor plugin call, it doesn't play the sound after 5 minutes in the background.
It does play the sound however when called inside the location callback.
So in order to play the sound there's a need to make sure it is done in the location callback inside the native code.
So the solution is to pass the route to the native code and have the calculation run there including when to sound the notification.
I haven't tested this on iOS still, but I did test it on Android which seems to work as expected.
The previous solution of playSound did not solve the problem.
